### PR TITLE
Sort members by default

### DIFF
--- a/src/GraphQL.DI/AutoInputObjectGraphType.cs
+++ b/src/GraphQL.DI/AutoInputObjectGraphType.cs
@@ -70,11 +70,22 @@ namespace GraphQL.DI
         }
 
         /// <summary>
+        /// Indicates that the fields and arguments should be added to the graph type alphabetically.
+        /// </summary>
+        public static bool SortMembers { get; set; } = true;
+
+        /// <summary>
         /// Returns a list of properties that should have fields created for them.
+        /// Sorts the list if specified by <see cref="SortMembers"/>.
         /// </summary>
         protected virtual IEnumerable<PropertyInfo> GetRegisteredProperties()
-            => typeof(TSourceType).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        {
+            var props = typeof(TSourceType).GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(x => x.CanWrite);
+            if (SortMembers)
+                props = props.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase);
+            return props;
+        }
 
         /// <summary>
         /// Processes the specified property and returns a <see cref="FieldType"/>


### PR DESCRIPTION
Reflection does not consistently return members in the same order, probably due to partial build capability within VS Pro.  As a consequence, running an introspection comparison test against the schema may intermittently fail if members are unsorted.